### PR TITLE
解决第一次启动没有config文件的生成问题

### DIFF
--- a/Model/ConfigManager.cs
+++ b/Model/ConfigManager.cs
@@ -19,19 +19,36 @@ namespace M9AWPF.Model
     }
     internal class ConfigManager
     {
-        const string path= @"./M9A-Bin/config.json";
+        const string path = @"./M9A-Bin/config.json";
         static string targetConfigFilepath;
         static ConfigObject configObject;
         public static List<BoxedMAATask> boxedMAATasks;
-        static ConfigManager()//按路径初始化
 
+        static ConfigManager()//按路径初始化
         {
-            targetConfigFilepath = path;
-            StreamReader sr = File.OpenText(path);
-            string jsonString = sr.ReadToEnd();
-            configObject = JsonSerializer.Deserialize<ConfigObject>(jsonString);
-            sr.Close();
+            // 存在文件则打开，没有文件则创建文件
+            if (File.Exists(path))
+            {
+                targetConfigFilepath = path;
+                StreamReader sr = File.OpenText(path);
+                string jsonString = sr.ReadToEnd();
+                configObject = JsonSerializer.Deserialize<ConfigObject>(jsonString);
+                sr.Close();
+            }
+            else
+            {
+                // 创建一个新文件
+                var sr = File.Open(path, FileMode.CreateNew);
+                sr.Close();
+
+                // 初始化json object，并且将其默认内容写入文件
+                configObject = new();
+                string jsonString = JsonSerializer.Serialize(configObject);
+                jsonString = jsonString.Replace("null", "{}");
+                File.WriteAllText(path, jsonString, new UTF8Encoding(false));
+            }
         }
+
         public static void SaveConfig()//保存到原文件
         {
             List<MAATask> maaTasks = new List<MAATask>();
@@ -82,6 +99,7 @@ namespace M9AWPF.Model
         {
             get
             {
+                if (configObject.adb_address == null || configObject.adb_address == string.Empty) return -1;
                 int temp = configObject.adb_address.IndexOf(":") + 1;
                 return int.Parse(configObject.adb_address[temp..]);
             }

--- a/Model/MAAConfigObject.cs
+++ b/Model/MAAConfigObject.cs
@@ -11,12 +11,12 @@ namespace M9AWPF.Model
     [Serializable]
     public class ConfigObject
     {
-        public string adb { get; set; }
-        public string adb_address { get; set; }
+        public string adb { get; set; } = "";
+        public string adb_address { get; set; } = "";
         public int client_type { get; set; }
         public bool debug { get; set; }
         public int screencap { get; set; }
-        public List<MAATask> tasks { get; set; }
+        public List<MAATask> tasks { get; set; } = new List<MAATask>(); // 初始化避免为null
         public int touch { get; set; }
         public string version { get; set; } = "v0.2.0";
     }


### PR DESCRIPTION
如果启动时不存在config文件，则创建，并且将默认生成的配置写入。为了兼容这个设置，修改了 ConfigObject 类的一些成员的默认值，此外，对于adb_address的端口，当第一次进入时，其默认值为-1.