### PR TITLE
精简Item Group，并且添加构建任务结束后下载M9A的task

### DIFF
--- a/M9AWPF.csproj
+++ b/M9AWPF.csproj
@@ -98,7 +98,7 @@
     </Task>
   </UsingTask>
 
-  <Target Name="M9A" AfterTargets="Build">
+  <Target Name="M9A" AfterTargets="Build" Condition="'$(Configuration)'=='Debug'">
     <!-- M9A 1.0.0-btea3 -->
     <Download
       url="https://github.com/MaaXYZ/M9A/releases/download/v1.0.0-beta.3/M9A-win-x86_64-v1.0.0-beta.3.zip"

--- a/M9AWPF.csproj
+++ b/M9AWPF.csproj
@@ -10,24 +10,18 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <None Remove="Font/fa.ttf" />
-    </ItemGroup>
-    
-    <ItemGroup>
+    <!-- 项目引用 -->
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
         <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.77" />
         <PackageReference Include="ModernWpfUI" Version="0.9.6" />
-    </ItemGroup>
     
     <!-- 复制文件/文件夹 -->
-    <ItemGroup>
         <!-- M9A-bin -->
-        <None Include="$(SolutionDir)M9A-Bin/**">
+    <None Include="$(ProjectDir)/M9A-Bin/**">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
         
-        <Resource Include="$(SolutionDir)Font/fa.ttf">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </Resource>
+    <!-- 资源 -->
+    <Resource Include="$(ProjectDir)/Font/fa.ttf" />
     </ItemGroup>
 </Project>

--- a/M9AWPF.csproj
+++ b/M9AWPF.csproj
@@ -1,27 +1,108 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    
-    <PropertyGroup>
-        <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0-windows</TargetFramework>
-        <Nullable>enable</Nullable>
-        <UseWPF>true</UseWPF>
-        <!-- 避免ModernWpfUI生成大量语言Resources -->
-        <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
-    </PropertyGroup>
-    
-    <ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
+    <!-- 避免ModernWpfUI生成大量语言Resources -->
+    <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
+  </PropertyGroup>
+
+  <ItemGroup>
     <!-- 项目引用 -->
-        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
-        <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.77" />
-        <PackageReference Include="ModernWpfUI" Version="0.9.6" />
-    
-    <!-- 复制文件/文件夹 -->
-        <!-- M9A-bin -->
-    <None Include="$(ProjectDir)/M9A-Bin/**">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
-        
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.77" />
+    <PackageReference Include="ModernWpfUI" Version="0.9.6" />
+
     <!-- 资源 -->
     <Resource Include="$(ProjectDir)/Font/fa.ttf" />
-    </ItemGroup>
+  </ItemGroup>
+
+
+
+  <!-- 从一个链接下载文件，并将其置于目标目录中 -->
+  <UsingTask TaskName="Download" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <!-- 下载链接 -->
+      <url Required="true" ParameterType="System.String" />
+      <!-- 保存目录 -->
+      <saveDir Required="true" ParameterType="System.String" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.IO.Compression" />
+      <Using Namespace="System.Net" />
+      <Using Namespace="System.Net.Http" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+        
+        // 存在目标目录直接返回
+        if(Directory.Exists(saveDir))
+        {
+            Log.LogMessage("已存在目标目录，跳过");
+            return true;
+        }
+        
+        // 没有目标目录则创建
+        Log.LogMessage("创建目标目录");
+        Directory.CreateDirectory(saveDir);
+        
+        // 本地文件路径用于写入待下载文件
+        string fileName = "M9A-Bin.zip";
+        string filePath=Path.Combine(new string[] {saveDir, fileName});
+        
+        // 下载
+        Log.LogMessage("开始下载...");
+        try
+        {
+            HttpWebRequest request = WebRequest.Create(url) as HttpWebRequest;
+            HttpWebResponse response = request.GetResponse() as HttpWebResponse;
+            Stream responseStream = response.GetResponseStream(); // Http流
+            Stream stream = new FileStream(filePath, FileMode.Create); // 文件流
+
+            ulong allSize = 0; // 总共下载了多少bytes
+            byte[] bArr = new byte[1024]; // 缓存区
+            int size = responseStream.Read(bArr, 0, (int)bArr.Length); // 读取多少字节
+            while (size > 0)
+            {
+                stream.Write(bArr, 0, size);
+                allSize += (ulong)size;
+                Log.LogMessage($"已下载 {allSize} bytes");
+                size = responseStream.Read(bArr, 0, (int)bArr.Length);
+            }
+            
+            stream.Close();
+            responseStream.Close();
+            Log.LogMessage("End Download");
+        }
+        catch
+        {
+            Log.LogError($"下载失败，请从 {url} 手动下载！");
+            return false;
+        }
+        
+        // 解压缩
+        Log.LogMessage("开始解压缩...");
+        ZipFile.ExtractToDirectory(filePath, saveDir);
+        
+        // 删除下载文件
+        Log.LogMessage("清除缓存...");
+        File.Delete(filePath);
+        
+        return true;
+        
+      ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <Target Name="M9A" AfterTargets="Build">
+    <!-- M9A 1.0.0-btea3 -->
+    <Download
+      url="https://github.com/MaaXYZ/M9A/releases/download/v1.0.0-beta.3/M9A-win-x86_64-v1.0.0-beta.3.zip"
+      saveDir="$(OutDir)/M9A-Bin/" />
+    <Message Text="Finished Download" />
+  </Target>
 </Project>


### PR DESCRIPTION
这个PR有两个commit，主要做了两件事情：
1. 把散乱的ItemGroup合并到一起，对于某些无用的选项进行了精简（如ttf资源文件中，使用Resource字段本身会将资源编译到程序集里面，便不必再CopyToOutputDirectory）。
2. 使用内联任务在M9AWPF的csproj中添加了一个任务，在Build 目标结束后，会自动下载M9A到输出文件夹里面。通过这种方式将M9A的版本控制通过文本内容在csproj里面实现，在这个PR中，采用了M9A 1.0.0-beta3的版本。

需要注意的是：
1. 任务接收两个输入参数，分别是url（要下载的链接），和saveDir（要用来保存内容的目录，在M9A这个target中，设置为M9A-Bin）。在任务开始的时候会检查该目录是否存在，如果存在则认为不需要下载，跳过任务，没有进行版本检查。而如果要更新M9A的话，则需要将原来生成的bin文件夹全部删除，然后重新构建，则会重新触发下载任务。
2. 任务默认认为下载下来的是一个zip压缩包，因此没有进行多压缩格式的兼容。
3. 任务默认认为下载下来的压缩包内不再有多级目录，而是直接是interface.json等一系列文件的目录，因此解压缩到目标目录后不会再检查是否还有目录包着，之后直接进入清除缓存（删除下载的压缩包等文件）的过程。
4. 任务执行的时机在Build任务之后，因此如果在程序本身构建阶段出了问题，则不会触发下载任务。
5. 用vs在构建的过程中要查看详细的构建中输出的内容的话，需要在 工具->选项->项目和解决方案->生成并运行->MS Build项目生成输出详细程度 中，改成至少是正常，这样才能看到输出的Message。

一方面，我最开始的想法是在同一个解决方案下另外设置一个新的项目，然后让主项目依赖该项目，然后自定义设计该项目的构建输出。但从MS文档上来看，自定义构建任务，需要新建解决方案（不要使用同一个解决方案），新建项目，然后构建出程序集后交给主解决方案里的项目引用，感觉这种方式稍微有点繁琐，因此使用了内联任务，即将任务代码直接内联写在目标项目的csproj里面，缺点是不方便写稍微复杂些的任务，而且没有代码提示和格式化等方便的工具。

另外一方面，因为下载的链接是github上的，因此如果不挂梯子或者用些别的手段的话恐怕很难成功构建，这时会报错，提示请手动从目标url下载内容，我也是全程挂着梯子才能测试下载功能。

从上述两个方面的角度来看，感觉稍微有点鸡肋，但还是放在这里作为一个参考。如果合的话，我后面就看情况看能不能再做一些改进；如果不合的话，我后面就再做些其他方面的改进，然后尝试做一下诸如定时器等的新功能。但无论合与不合，还是希望能接受第一个精简Item Group的改动，这个感觉还是好的。